### PR TITLE
Add Decap CMS for blog editing

### DIFF
--- a/site/static/admin/config.yml
+++ b/site/static/admin/config.yml
@@ -1,0 +1,67 @@
+# Decap CMS configuration for the UBIK blog
+# Docs: https://decapcms.org/docs/
+
+backend:
+  name: github
+  repo: UBIKhr/web
+  branch: master
+  # OAuth proxy for GitHub login. Replace with the URL of the deployed
+  # Cloudflare Worker / Render / Vercel proxy once it's live.
+  # Example: https://decap-oauth.<your-account>.workers.dev
+  base_url: https://REPLACE_WITH_OAUTH_PROXY_URL
+  auth_endpoint: /auth
+
+# Open editorial workflow (drafts go through PRs instead of pushing
+# directly to master). Recommended — gives an approval step.
+publish_mode: editorial_workflow
+
+# Where uploaded images go (relative to repo root) and how Hugo serves them.
+media_folder: "site/static/images/blog"
+public_folder: "/images/blog"
+
+# Site URL shown in the editor preview pane.
+site_url: https://blog.ubik.hr
+display_url: https://blog.ubik.hr
+logo_url: https://blog.ubik.hr/images/logo-bg.jpeg
+
+# Locale of the CMS UI (the editor interface, not the content).
+locale: "en"
+
+collections:
+  - name: "blog_hr"
+    label: "Blog (Hrvatski)"
+    label_singular: "Objava"
+    folder: "site/content/croatian/blog"
+    create: true
+    slug: "{{slug}}"
+    extension: "md"
+    format: "yaml-frontmatter"
+    summary: "{{title}} — {{date | date('YYYY-MM-DD')}}"
+    fields:
+      - { label: "Naslov", name: "title", widget: "string" }
+      - { label: "Datum", name: "date", widget: "datetime", date_format: "YYYY-MM-DD", time_format: false, picker_utc: false }
+      - { label: "Autor", name: "author", widget: "string", default: "UBIK" }
+      - { label: "Skica (draft)", name: "draft", widget: "boolean", default: true }
+      - { label: "Naslovna slika", name: "image", widget: "image", required: false, hint: "Sprema se u /images/blog/" }
+      - { label: "Tagovi", name: "tags", widget: "list", required: false, hint: "Pojedinačni tagovi, npr. blockchain, regulativa" }
+      - { label: "Type", name: "type", widget: "hidden", default: "post" }
+      - { label: "Tijelo", name: "body", widget: "markdown" }
+
+  - name: "blog_en"
+    label: "Blog (English)"
+    label_singular: "Post"
+    folder: "site/content/english/blog"
+    create: true
+    slug: "{{slug}}"
+    extension: "md"
+    format: "yaml-frontmatter"
+    summary: "{{title}} — {{date | date('YYYY-MM-DD')}}"
+    fields:
+      - { label: "Title", name: "title", widget: "string" }
+      - { label: "Date", name: "date", widget: "datetime", date_format: "YYYY-MM-DD", time_format: false, picker_utc: false }
+      - { label: "Author", name: "author", widget: "string", default: "UBIK" }
+      - { label: "Draft", name: "draft", widget: "boolean", default: true }
+      - { label: "Cover image", name: "image", widget: "image", required: false, hint: "Saved under /images/blog/" }
+      - { label: "Tags", name: "tags", widget: "list", required: false }
+      - { label: "Type", name: "type", widget: "hidden", default: "post" }
+      - { label: "Body", name: "body", widget: "markdown" }

--- a/site/static/admin/index.html
+++ b/site/static/admin/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex" />
+    <title>UBIK Blog – Content Manager</title>
+  </head>
+  <body>
+    <!-- Include the Decap CMS script -->
+    <script src="https://unpkg.com/decap-cms@^3.0.0/dist/decap-cms.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
Adds [Decap CMS](https://decapcms.org) to the blog so editors can publish posts via a web UI at **https://blog.ubik.hr/admin/** without touching git directly.

## Changes
- `site/static/admin/index.html` — loads Decap CMS from the public CDN
- `site/static/admin/config.yml`
  - `backend: github` (commits go to this repo)
  - `publish_mode: editorial_workflow` (drafts open as PRs against \`master\` instead of pushing directly — gives an approval step)
  - Two collections: **Blog (Hrvatski)** → \`site/content/croatian/blog\` and **Blog (English)** → \`site/content/english/blog\`
  - Front-matter fields match the format of existing posts: \`title\`, \`date\`, \`author\`, \`draft\`, \`image\`, \`tags\`, \`type: post\`, \`body\`
  - \`media_folder: site/static/images/blog\` so uploaded cover images land where Hugo expects them

## Action required after merge — set up OAuth proxy

The \`base_url\` in \`config.yml\` is a placeholder. To make login work, deploy a small OAuth proxy (free) and replace the placeholder with its URL.

**Recommended: Cloudflare Workers**
1. Register a new GitHub OAuth App: <https://github.com/settings/developers>
   - Homepage URL: \`https://blog.ubik.hr\`
   - Authorization callback URL: \`https://<your-worker>.workers.dev/callback\`
2. Deploy the [decap-proxy worker](https://github.com/sterlingwes/decap-proxy) on Cloudflare with two secrets: \`CLIENT_ID\`, \`CLIENT_SECRET\` from the OAuth App.
3. Update \`site/static/admin/config.yml\` → \`base_url: https://<your-worker>.workers.dev\`.
4. Visit \`https://blog.ubik.hr/admin/\` → "Login with GitHub".

(Alternative: stay on GH Pages but add a small Render/Vercel proxy — same idea.)

## Test plan
- [ ] After deploy, \`https://blog.ubik.hr/admin/\` loads the Decap UI
- [ ] After OAuth proxy is configured, "Login with GitHub" works
- [ ] Creating a new HR post writes a markdown file to \`site/content/croatian/blog/\` with correct front-matter
- [ ] Editorial workflow opens a PR against \`master\`
- [ ] Existing posts are listed in the CMS and editable

## Notes
- This is non-breaking — without the OAuth proxy URL set, the admin UI just won't authenticate. The blog itself is unaffected.
- \`<meta name="robots" content="noindex">\` is set on the admin page so it won't be indexed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)