### PR TITLE
Fix workflow: drop --openssl-legacy-provider flag (Node 16 incompatible)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,13 +21,10 @@ jobs:
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile --non-interactive --ignore-optional --network-timeout 600000
-        env:
-          NODE_OPTIONS: --openssl-legacy-provider
 
       - name: Build
         run: yarn build
         env:
-          NODE_OPTIONS: --openssl-legacy-provider
           HUGO_PARAMS_SUBSCRIPTION_mailchimpuser: ${{ secrets.HUGO_PARAMS_MAILCHIMP_U }}
 
       - name: Deploy 🚀


### PR DESCRIPTION
## Summary
PR #162's deploy run failed at the install step:

> \`node: --openssl-legacy-provider is not allowed in NODE_OPTIONS\`
> \`Process completed with exit code 9.\`

The \`--openssl-legacy-provider\` flag was added defensively for Node 17+ (where OpenSSL 3 broke older build tools). It doesn't exist on Node 16 — Node refuses to start. Removing it.

Node 16 ships OpenSSL 1.1, so Webpack 4 / node-sass build cleanly without any flags.

## Test plan
- [ ] Workflow run completes successfully
- [ ] gh-pages branch is updated
- [ ] blog.ubik.hr serves the latest content
- [ ] /admin/ from PR #161 loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)