### PR TITLE
Set Decap CMS OAuth proxy URL

### DIFF
--- a/site/static/admin/config.yml
+++ b/site/static/admin/config.yml
@@ -5,10 +5,8 @@ backend:
   name: github
   repo: UBIKhr/web
   branch: master
-  # OAuth proxy for GitHub login. Replace with the URL of the deployed
-  # Cloudflare Worker / Render / Vercel proxy once it's live.
-  # Example: https://decap-oauth.<your-account>.workers.dev
-  base_url: https://REPLACE_WITH_OAUTH_PROXY_URL
+  # OAuth proxy (Cloudflare Worker) handling GitHub login.
+  base_url: https://decap-proxy.lusucic.workers.dev
   auth_endpoint: /auth
 
 # Open editorial workflow (drafts go through PRs instead of pushing


### PR DESCRIPTION
## Summary
The \`base_url\` in \`site/static/admin/config.yml\` is still the placeholder \`https://REPLACE_WITH_OAUTH_PROXY_URL\`, which is why \`/admin/\` shows \`ERR_NAME_NOT_RESOLVED\` when trying to log in.

This sets it to the actual deployed Cloudflare Worker URL.

## Changes
- \`site/static/admin/config.yml\` → \`base_url: https://decap-proxy.lusucic.workers.dev\`

## Test plan
- [ ] After deploy, https://blog.ubik.hr/admin/ login button works
- [ ] OAuth flow completes and editor loads with HR + EN collections

🤖 Generated with [Claude Code](https://claude.com/claude-code)