### PR TITLE
Make blog.ubik.hr blog-only: redirect non-blog pages to ubik.hr

### DIFF
--- a/site/config.toml
+++ b/site/config.toml
@@ -140,41 +140,37 @@ languageName = "En"
 weight = 2
 
 ################### English navigation ####################
+# Non-blog pages live on the main Gatsby site at https://ubik.hr.
+# Only /blog/ is hosted on this Hugo deploy (blog.ubik.hr).
 [[Languages.en.menu.main]]
 name = "home"
-url = "/en"
+url = "https://ubik.hr/en"
 weight = 1
 
 [[Languages.en.menu.main]]
-name = "consulting"
-url = "/en/consulting"
+name = "arbitration"
+url = "https://ubik.hr/en/arbitraza"
 weight = 2
 
 [[Languages.en.menu.main]]
-name = "arbitration"
-url = "/en/arbitration"
-weight = 3
-
-
-[[Languages.en.menu.main]]
 name = "blog"
-url = "blog"
-weight = 4
+url = "/en/blog"
+weight = 3
 
 [[Languages.en.menu.main]]
 name = "members"
-url = "members"
-weight = 5
+url = "https://ubik.hr/en/members"
+weight = 4
 
 [[Languages.en.menu.main]]
 name = "Contact"
-url = "contact"
-weight = 6
+url = "https://ubik.hr/en/contact"
+weight = 5
 
 [[Languages.en.menu.main]]
 name = "Become a member"
-url = "become-a-member"
-weight = 7
+url = "https://ubik.hr/en/join"
+weight = 6
 
 ################################### Croatian language #####################################
 [Languages.hr]
@@ -185,6 +181,8 @@ languageName = "Hr"
 weight = 1
 
 ################### Croatian navigation ####################
+# Non-blog pages live on the main Gatsby site at https://ubik.hr.
+# Only /blog/ is hosted on this Hugo deploy (blog.ubik.hr).
 
 # main menu
 [[Languages.hr.menu.main]]
@@ -193,28 +191,23 @@ url = "blog"
 weight = 1
 
 [[Languages.hr.menu.main]]
-name = "Savjetovanje"
-url = "consulting"
+name = "Arbitraža"
+url = "https://ubik.hr/arbitraza"
 weight = 2
 
 [[Languages.hr.menu.main]]
-name = "Arbitraža"
-url = "arbitration"
-weight = 3
-
-[[Languages.hr.menu.main]]
 name = "članovi"
-url = "members"
+url = "https://ubik.hr/members"
 weight = 3
 
 [[Languages.hr.menu.main]]
 name = "kontakt"
-url = "contact"
+url = "https://ubik.hr/contact"
 weight = 4
 
 [[Languages.hr.menu.main]]
 name = "Postani član"
-url = "become-a-member"
+url = "https://ubik.hr/join"
 weight = 5
 
 [markup.goldmark.renderer]

--- a/site/content/croatian/arbitration/_index.md
+++ b/site/content/croatian/arbitration/_index.md
@@ -1,5 +1,7 @@
 ---
-title: "Arbitraža"
-draft: false
-description : ""
+title: "Redirecting…"
+type: "redirect"
+layout: "redirect"
+redirect_to: "https://ubik.hr/arbitraza/"
+sitemap_exclude: true
 ---

--- a/site/content/croatian/become-a-member/_index.md
+++ b/site/content/croatian/become-a-member/_index.md
@@ -1,5 +1,7 @@
 ---
-title: "Become a member"
-draft: false
-description : ""
+title: "Redirecting…"
+type: "redirect"
+layout: "redirect"
+redirect_to: "https://ubik.hr/join/"
+sitemap_exclude: true
 ---

--- a/site/content/croatian/consulting/_index.md
+++ b/site/content/croatian/consulting/_index.md
@@ -1,5 +1,7 @@
 ---
-title: "Savjetovanje"
-draft: false
-description : ""
+title: "Redirecting…"
+type: "redirect"
+layout: "redirect"
+redirect_to: "https://ubik.hr/"
+sitemap_exclude: true
 ---

--- a/site/content/croatian/contact/_index.md
+++ b/site/content/croatian/contact/_index.md
@@ -1,5 +1,7 @@
 ---
-title: ""
-draft: false
-description : ""
+title: "Redirecting…"
+type: "redirect"
+layout: "redirect"
+redirect_to: "https://ubik.hr/contact/"
+sitemap_exclude: true
 ---

--- a/site/content/croatian/members/_index.md
+++ b/site/content/croatian/members/_index.md
@@ -1,5 +1,7 @@
 ---
-title: "Our members"
-draft: false
-description : ""
+title: "Redirecting…"
+type: "redirect"
+layout: "redirect"
+redirect_to: "https://ubik.hr/members/"
+sitemap_exclude: true
 ---

--- a/site/content/english/arbitration/_index.md
+++ b/site/content/english/arbitration/_index.md
@@ -1,5 +1,7 @@
 ---
-title: "Arbitration"
-draft: false
-description : ""
+title: "Redirecting…"
+type: "redirect"
+layout: "redirect"
+redirect_to: "https://ubik.hr/en/arbitraza/"
+sitemap_exclude: true
 ---

--- a/site/content/english/become-a-member/_index.md
+++ b/site/content/english/become-a-member/_index.md
@@ -1,5 +1,7 @@
 ---
-title: "Become a member"
-draft: false
-description : ""
+title: "Redirecting…"
+type: "redirect"
+layout: "redirect"
+redirect_to: "https://ubik.hr/en/join/"
+sitemap_exclude: true
 ---

--- a/site/content/english/consulting/_index.md
+++ b/site/content/english/consulting/_index.md
@@ -1,5 +1,7 @@
 ---
-title: "Consulting"
-draft: false
-description : ""
+title: "Redirecting…"
+type: "redirect"
+layout: "redirect"
+redirect_to: "https://ubik.hr/en/"
+sitemap_exclude: true
 ---

--- a/site/content/english/contact/_index.md
+++ b/site/content/english/contact/_index.md
@@ -1,5 +1,7 @@
 ---
-title: ""
-draft: false
-description : ""
+title: "Redirecting…"
+type: "redirect"
+layout: "redirect"
+redirect_to: "https://ubik.hr/en/contact/"
+sitemap_exclude: true
 ---

--- a/site/content/english/members/_index.md
+++ b/site/content/english/members/_index.md
@@ -1,5 +1,7 @@
 ---
-title: "Our members"
-draft: false
-description : ""
+title: "Redirecting…"
+type: "redirect"
+layout: "redirect"
+redirect_to: "https://ubik.hr/en/members/"
+sitemap_exclude: true
 ---

--- a/site/layouts/_default/redirect.html
+++ b/site/layouts/_default/redirect.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="{{ .Site.Language.Lang }}">
+  <head>
+    <meta charset="utf-8">
+    <title>Redirecting…</title>
+    <link rel="canonical" href="{{ .Params.redirect_to }}">
+    <meta name="robots" content="noindex">
+    <meta http-equiv="refresh" content="0; url={{ .Params.redirect_to }}">
+  </head>
+  <body>
+    <p>This page has moved. Redirecting to <a href="{{ .Params.redirect_to }}">{{ .Params.redirect_to }}</a>…</p>
+    <script>window.location.replace("{{ .Params.redirect_to }}");</script>
+  </body>
+</html>

--- a/site/layouts/redirect/list.html
+++ b/site/layouts/redirect/list.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="{{ .Site.Language.Lang }}">
+  <head>
+    <meta charset="utf-8">
+    <title>Redirecting…</title>
+    <link rel="canonical" href="{{ .Params.redirect_to }}">
+    <meta name="robots" content="noindex">
+    <meta http-equiv="refresh" content="0; url={{ .Params.redirect_to }}">
+  </head>
+  <body>
+    <p>This page has moved. Redirecting to <a href="{{ .Params.redirect_to }}">{{ .Params.redirect_to }}</a>…</p>
+    <script>window.location.replace("{{ .Params.redirect_to }}");</script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
The Hugo deploy at \`blog.ubik.hr\` was originally the entire ubik.hr website. After the migration to Gatsby (now serving ubik.hr), this repo was repurposed to host only \`/blog/\`, but the navbar and the old non-blog pages (members, contact, arbitration, consulting, become-a-member) were left in place — so visitors clicking the navbar landed on stale 2024 content.

This PR makes \`blog.ubik.hr\` truly blog-only:

1. **Updates the navbar** (HR + EN) so all non-blog links point to https://ubik.hr (absolute URLs).
2. **Adds redirects** on every non-blog section page so anyone arriving via direct URL or search engine gets sent to the corresponding ubik.hr page.

## URL mapping

| Old (blog.ubik.hr) | New target (ubik.hr) |
| --- | --- |
| \`/members/\`, \`/en/members/\` | \`/members/\`, \`/en/members/\` |
| \`/contact/\`, \`/en/contact/\` | \`/contact/\`, \`/en/contact/\` |
| \`/arbitration/\`, \`/en/arbitration/\` | \`/arbitraza/\`, \`/en/arbitraza/\` |
| \`/become-a-member/\`, \`/en/become-a-member/\` | \`/join/\`, \`/en/join/\` |
| \`/consulting/\`, \`/en/consulting/\` | \`/\` (Gatsby has no consulting page) |

## Changes
- \`site/config.toml\` — navbar URLs (HR + EN) updated to absolute ubik.hr links; \`/blog/\` stays relative
- \`site/content/{croatian,english}/{members,contact,arbitration,consulting,become-a-member}/_index.md\` — replaced with redirect front-matter (\`type: redirect\`, \`redirect_to: ...\`, \`sitemap_exclude: true\`)
- \`site/layouts/_default/redirect.html\` and \`site/layouts/redirect/list.html\` — new template emitting:
  - \`<meta http-equiv="refresh" content="0; url=...">\`
  - \`<link rel="canonical">\`
  - \`<meta name="robots" content="noindex">\`
  - JS \`window.location.replace\` fallback

## Out of scope (intentional)
- The Hugo home page at \`blog.ubik.hr/\` is left as-is. Decide separately whether it should redirect to \`ubik.hr/\` or to \`blog.ubik.hr/blog/\`.
- Individual member detail pages (e.g. \`/members/luka-sucic/\`) are not redirected — only section landing pages. Open a follow-up if you want those handled too.

## Backups
Before this PR, the state was tagged for permanent recovery:
- \`backup/pre-blog-cleanup\` — master source
- \`backup/built-site-pre-cleanup\` — built gh-pages site

## Test plan
- [ ] Workflow run succeeds
- [ ] Click "Members" / "Contact" / "Arbitraža" / "Postani član" in navbar at \`blog.ubik.hr\` → lands on the corresponding ubik.hr page
- [ ] Direct visit \`https://blog.ubik.hr/members/\` → redirects to \`https://ubik.hr/members/\`
- [ ] Same checks for \`/en/\` variants
- [ ] \`https://blog.ubik.hr/blog/\` still works
- [ ] No regressions in blog post rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)