### PR TITLE
Drop broken Telegram notifier; redirect blog home → /blog/

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,12 +34,3 @@ jobs:
           branch: gh-pages
           folder: dist
           clean: true
-
-      - name: Notify deployment
-        uses: appleboy/telegram-action@master
-        with:
-          to: ${{ secrets.TELEGRAM_TO }}
-          token: ${{ secrets.TELEGRAM_TOKEN }}
-          format: markdown
-          message:
-            Blog je ažuriran. [Vidi promjene](https://github.com/UBIKhr/web/commit/${{ github.sha }}).

--- a/site/layouts/index.html
+++ b/site/layouts/index.html
@@ -1,0 +1,15 @@
+{{- $target := "/blog/" -}}
+{{- if eq .Site.Language.Lang "en" -}}{{- $target = "/en/blog/" -}}{{- end -}}
+<!doctype html>
+<html lang="{{ .Site.Language.Lang }}">
+  <head>
+    <meta charset="utf-8">
+    <title>UBIK Blog</title>
+    <link rel="canonical" href="{{ $target }}">
+    <meta http-equiv="refresh" content="0; url={{ $target }}">
+  </head>
+  <body>
+    <p>Redirecting to <a href="{{ $target }}">{{ $target }}</a>…</p>
+    <script>window.location.replace("{{ $target }}");</script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
Two cleanups:

### 1. Remove broken Telegram notification step
The \`appleboy/telegram-action\` step in \`publish.yml\` was failing on every run with:
\`Forbidden: bot was kicked from the supergroup chat\`

This caused the workflow to be marked as failed even though the deploy itself succeeded — misleading any time someone glances at the Actions tab. Removing the step.

(If Telegram notifications are still wanted later, easiest fix is to invite the bot back to the chat and add the step in. For now: dropped.)

### 2. Redirect blog home pages to the blog index
\`https://blog.ubik.hr/\` and \`/en/\` were rendering the legacy Hugo home page. Since this site is now blog-only, we send users straight to where the content lives:

| URL | Redirects to |
| --- | --- |
| \`https://blog.ubik.hr/\` | \`/blog/\` |
| \`https://blog.ubik.hr/en/\` | \`/en/blog/\` |

## Changes
- \`.github/workflows/publish.yml\` — drop the \`Notify deployment\` step
- \`site/layouts/index.html\` — new project-level home layout that emits a meta-refresh + JS redirect to the language-appropriate blog index

## Test plan
- [ ] Workflow run shows green ✅ (no more spurious failure)
- [ ] \`https://blog.ubik.hr/\` redirects to \`/blog/\`
- [ ] \`https://blog.ubik.hr/en/\` redirects to \`/en/blog/\`
- [ ] Direct visits to \`/blog/\` still work as the actual blog index

🤖 Generated with [Claude Code](https://claude.com/claude-code)