### PR TITLE
Publish Test Blog post

### DIFF
--- a/site/content/croatian/blog/test-blog.md
+++ b/site/content/croatian/blog/test-blog.md
@@ -2,7 +2,7 @@
 title: Test Blog
 date: 2025-12-12
 author: UBIK
-draft: true
+draft: false
 type: post
 ---
 Test test test


### PR DESCRIPTION
Flips `draft: true` → `false` on `site/content/croatian/blog/test-blog.md` so Hugo includes it in the production build.

The post was created via Decap CMS without unchecking the Skica/Draft toggle in the editor, so it merged as a draft and never rendered.